### PR TITLE
clean-up exglobal_atmos_sfcanl.sh and update the j-job for COMIN/COMOUT

### DIFF
--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -5,39 +5,33 @@ source "${HOMEgfs}/ush/jjob_header.sh" -e "sfcanl" -c "base sfcanl"
 
 
 ##############################################
-# Set variables used in the script
-##############################################
-export CDUMP="${RUN/enkf}"
-
-
-##############################################
 # Begin JOB SPECIFIC work
 ##############################################
 # Ignore possible spelling error (nothing is misspelled)
 # shellcheck disable=SC2153
-GDATE=$(${NDATE} -"${assim_freq}" "${PDY}${cyc}")
-# shellcheck disable=
-gPDY=${GDATE:0:8}
-gcyc=${GDATE:8:2}
-export GDUMP="gdas"
+GDATE=$(date --utc -d "${PDY} ${cyc} - ${assim_freq} hours" +%Y%m%d%H)
 
-export OPREFIX="${CDUMP}.t${cyc}z."
-export GPREFIX="${GDUMP}.t${gcyc}z."
-export APREFIX="${CDUMP}.t${cyc}z."
+RUN="gdas" YMD=${GDATE:0:8} HH=${GDATE:8:2} declare_from_tmpl -rx \
+  COMIN_OBS_PREV:COM_OBS_TMPL \
+  COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
 
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS COM_ATMOS_ANALYSIS COM_ATMOS_RESTART \
-    COM_SNOW_ANALYSIS
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
+  COMIN_OBS:COM_OBS_TMPL \
+  COMIN_ATMOS_ANALYSIS:COM_ATMOS_ANALYSIS_TMPL \
+  COMIN_SNOW_ANALYSIS:COM_SNOW_ANALYSIS_TMPL
 
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COM_OBS_PREV:COM_OBS_TMPL \
-    COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
+  COMOUT_ATMOS_RESTART:COM_ATMOS_RESTART_TMPL
+
+mkdir -p "${COMOUT_ATMOS_RESTART}"
+
 
 ###############################################################
 # Run relevant script
 
 ${SFCANALSH:-${SCRgfs}/exglobal_atmos_sfcanl.sh}
 status=$?
-[[ ${status} -ne 0 ]] && exit ${status}
+(( status != 0 )) && exit ${status}
 
 
 ##############################################

--- a/jobs/JGLOBAL_ATMOS_SFCANL
+++ b/jobs/JGLOBAL_ATMOS_SFCANL
@@ -31,7 +31,7 @@ mkdir -p "${COMOUT_ATMOS_RESTART}"
 
 ${SFCANALSH:-${SCRgfs}/exglobal_atmos_sfcanl.sh}
 status=$?
-(( status != 0 )) && exit ${status}
+(( status != 0 )) && exit "${status}"
 
 
 ##############################################
@@ -42,14 +42,14 @@ status=$?
 # Final processing
 ##############################################
 if [[ -e "${pgmout}" ]] ; then
-  cat ${pgmout}
+  cat "${pgmout}"
 fi
 
 ##########################################
 # Remove the Temporary working directory
 ##########################################
-cd ${DATAROOT}
-[[ ${KEEPDATA} = "NO" ]] && rm -rf ${DATA}
+cd "${DATAROOT}"
+[[ "${KEEPDATA}" == "NO" ]] && rm -rf "${DATA}"
 
 
 exit 0

--- a/scripts/exglobal_atmos_sfcanl.sh
+++ b/scripts/exglobal_atmos_sfcanl.sh
@@ -69,13 +69,13 @@ FNSNOG=${FNSNOG:-${COMIN_OBS_PREV}/${GPREFIX}snogrb_t${JCAP_CASE}.${LONB_CASE}.$
 
 # Set CYCLVARS by checking grib date of current snogrb vs that of prev cycle
 if [[ ${RUN_GETGES} = "YES" ]]; then
-  snoprv=$(${GETGESSH} -q -t snogrb_${JCAP_CASE} -e ${gesenvir} -n ${GDUMP} -v ${GDATE})
+  snoprv=$(${GETGESSH} -q -t "snogrb_${JCAP_CASE}" -e "${gesenvir}" -n "${GDUMP}" -v "${GDATE}")
 else
   snoprv=${snoprv:-${FNSNOG}}
 fi
 
-if [[ $(${WGRIB} -4yr ${FNSNOA} 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') -le \
-  $(${WGRIB} -4yr ${snoprv} 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') ]] ; then
+if [[ $(${WGRIB} -4yr "${FNSNOA}" 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') -le \
+  $(${WGRIB} -4yr "${snoprv}" 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') ]] ; then
   export FNSNOA=" "
   export CYCLVARS="FSNOL=99999.,FSNOS=99999.,"
 else

--- a/scripts/exglobal_atmos_sfcanl.sh
+++ b/scripts/exglobal_atmos_sfcanl.sh
@@ -22,200 +22,128 @@
 source "${USHgfs}/preamble.sh"
 
 #  Directories.
-pwd=$(pwd)
+cd "${DATA}" || exit 99
 
 # Derived base variables
 # Ignore possible spelling error (nothing is misspelled)
 # shellcheck disable=SC2153
-GDATE=$(${NDATE} -"${assim_freq}" "${PDY}${cyc}")
-BDATE=$(${NDATE} -3 "${PDY}${cyc}")
-bPDY=${BDATE:0:8}
-bcyc=${BDATE:8:2}
+GDATE=$(date --utc -d "${PDY} ${cyc} - ${assim_freq} hours" +%Y%m%d%H)
 
-# Utilities
-export CHGRP_CMD=${CHGRP_CMD:-"chgrp ${group_name:-rstprod}"}
-export NCLEN=${NCLEN:-${USHgfs}/getncdimlen}
-COMPRESS=${COMPRESS:-gzip}
-UNCOMPRESS=${UNCOMPRESS:-gunzip}
-APRUNCFP=${APRUNCFP:-""}
-
-# IAU
-DOIAU=${DOIAU:-"NO"}
-export IAUFHRS=${IAUFHRS:-"6"}
-
-# Surface cycle related parameters
+# Dependent Scripts and Executables
 CYCLESH=${CYCLESH:-${USHgfs}/global_cycle.sh}
 export CYCLEXEC=${CYCLEXEC:-${EXECgfs}/global_cycle}
 NTHREADS_CYCLE=${NTHREADS_CYCLE:-24}
 APRUN_CYCLE=${APRUN_CYCLE:-${APRUN:-""}}
+
+# Surface cycle related parameters
 export SNOW_NUDGE_COEFF=${SNOW_NUDGE_COEFF:-'-2.'}
 export CYCLVARS=${CYCLVARS:-""}
 export FHOUR=${FHOUR:-0}
 export DELTSFC=${DELTSFC:-6}
 
-# FV3 specific info (required for global_cycle)
-export CASE=${CASE:-"C384"}
-ntiles=${ntiles:-6}
-
-# IAU
-DOIAU=${DOIAU:-"NO"}
-export IAUFHRS=${IAUFHRS:-"6"}
-
-# Dependent Scripts and Executables
-export NTHREADS_CALCINC=${NTHREADS_CALCINC:-1}
-export APRUN_CALCINC=${APRUN_CALCINC:-${APRUN:-""}}
-export APRUN_CALCANL=${APRUN_CALCANL:-${APRUN:-""}}
-export APRUN_CHGRES=${APRUN_CALCANL:-${APRUN:-""}}
-
-export CALCANLEXEC=${CALCANLEXEC:-${EXECgfs}/calc_analysis.x}
-export CHGRESNCEXEC=${CHGRESNCEXEC:-${EXECgfs}/enkf_chgres_recenter_nc.x}
-export CHGRESINCEXEC=${CHGRESINCEXEC:-${EXECgfs}/interp_inc.x}
-export NTHREADS_CHGRES=${NTHREADS_CHGRES:-1}
-CALCINCPY=${CALCINCPY:-${USHgfs}/calcinc_gfs.py}
-CALCANLPY=${CALCANLPY:-${USHgfs}/calcanl_gfs.py}
-
-export APRUN_CHGRES=${APRUN_CALCANL:-${APRUN:-""}}
-CHGRESEXEC=${CHGRESEXEC:-${EXECgfs}/enkf_chgres_recenter.x}
-
-# OPS flags
-RUN=${RUN:-""}
-SENDECF=${SENDECF:-"NO"}
-SENDDBN=${SENDDBN:-"NO"}
+# Other info used in this script
 RUN_GETGES=${RUN_GETGES:-"NO"}
 GETGESSH=${GETGESSH:-"getges.sh"}
 export gesenvir=${gesenvir:-${envir}}
+GPREFIX="gdas.t${GDATE:8:2}z."
+OPREFIX="${RUN/enkf}.t${cyc}z."
+APREFIX="${RUN/enkf}.t${cyc}z."
 
-# Observations
-OPREFIX=${OPREFIX:-""}
-OSUFFIX=${OSUFFIX:-""}
+ntiles=6
 
-# Guess files
-GPREFIX=${GPREFIX:-""}
 
-# Analysis files
-export APREFIX=${APREFIX:-""}
-DTFANL=${DTFANL:-${COM_ATMOS_ANALYSIS}/${APREFIX}dtfanl.nc}
-
+##############################################################
 # Get dimension information based on CASE
-res=$(echo ${CASE} | cut -c2-)
+res="${CASE:1}"
 JCAP_CASE=$((res*2-2))
 LATB_CASE=$((res*2))
 LONB_CASE=$((res*4))
 
-################################################################################
-#  Preprocessing
-mkdata=NO
-if [[ ! -d ${DATA} ]]; then
-   mkdata=YES
-   mkdir -p ${DATA}
-fi
-
-cd ${DATA} || exit 99
-
-if [[ ${DONST} = "YES" ]]; then
-    export NSSTBF="${COM_OBS}/${OPREFIX}nsstbufr"
-    ${NLN} ${NSSTBF} nsstbufr
-fi
-
-
-##############################################################
-# Required model guess files
-
-
-##############################################################
-# Output files
-if [[ ${DONST} = "YES" ]]; then
-   ${NLN} ${DTFANL} dtfanl
-fi
-
-
-##############################################################
-# Update surface fields in the FV3 restart's using global_cycle
-mkdir -p "${COM_ATMOS_RESTART}"
-
 # Global cycle requires these files
-export FNTSFA=${FNTSFA:-${COM_OBS}/${OPREFIX}rtgssthr.grb}
-export FNACNA=${FNACNA:-${COM_OBS}/${OPREFIX}seaice.5min.blend.grb}
-export FNSNOA=${FNSNOA:-${COM_OBS}/${OPREFIX}snogrb_t${JCAP_CASE}.${LONB_CASE}.${LATB_CASE}}
-[[ ! -f ${FNSNOA} ]] && export FNSNOA="${COM_OBS}/${OPREFIX}snogrb_t1534.3072.1536"
-FNSNOG=${FNSNOG:-${COM_OBS_PREV}/${GPREFIX}snogrb_t${JCAP_CASE}.${LONB_CASE}.${LATB_CASE}}
-[[ ! -f ${FNSNOG} ]] && FNSNOG="${COM_OBS_PREV}/${GPREFIX}snogrb_t1534.3072.1536"
+export FNTSFA=${FNTSFA:-${COMIN_OBS}/${OPREFIX}rtgssthr.grb}
+export FNACNA=${FNACNA:-${COMIN_OBS}/${OPREFIX}seaice.5min.blend.grb}
+export FNSNOA=${FNSNOA:-${COMIN_OBS}/${OPREFIX}snogrb_t${JCAP_CASE}.${LONB_CASE}.${LATB_CASE}}
+[[ ! -f ${FNSNOA} ]] && export FNSNOA="${COMIN_OBS}/${OPREFIX}snogrb_t1534.3072.1536"
+FNSNOG=${FNSNOG:-${COMIN_OBS_PREV}/${GPREFIX}snogrb_t${JCAP_CASE}.${LONB_CASE}.${LATB_CASE}}
+[[ ! -f ${FNSNOG} ]] && FNSNOG="${COMIN_OBS_PREV}/${GPREFIX}snogrb_t1534.3072.1536"
 
 # Set CYCLVARS by checking grib date of current snogrb vs that of prev cycle
 if [[ ${RUN_GETGES} = "YES" ]]; then
-    snoprv=$(${GETGESSH} -q -t snogrb_${JCAP_CASE} -e ${gesenvir} -n ${GDUMP} -v ${GDATE})
+  snoprv=$(${GETGESSH} -q -t snogrb_${JCAP_CASE} -e ${gesenvir} -n ${GDUMP} -v ${GDATE})
 else
-    snoprv=${snoprv:-${FNSNOG}}
+  snoprv=${snoprv:-${FNSNOG}}
 fi
 
 if [[ $(${WGRIB} -4yr ${FNSNOA} 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') -le \
-    $(${WGRIB} -4yr ${snoprv} 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') ]] ; then
-    export FNSNOA=" "
-    export CYCLVARS="FSNOL=99999.,FSNOS=99999.,"
+  $(${WGRIB} -4yr ${snoprv} 2>/dev/null | grep -i snowc | awk -F: '{print $3}' | awk -F= '{print $2}') ]] ; then
+  export FNSNOA=" "
+  export CYCLVARS="FSNOL=99999.,FSNOS=99999.,"
 else
-    export SNOW_NUDGE_COEFF=${SNOW_NUDGE_COEFF:-0.}
-    export CYCLVARS="FSNOL=${SNOW_NUDGE_COEFF},${CYCLVARS}"
-fi
-
-if [[ ${DONST} = "YES" ]]; then
-    export NST_FILE=${GSI_FILE:-${COM_ATMOS_ANALYSIS}/${APREFIX}dtfanl.nc}
-else
-    export NST_FILE="NULL"
+  export CYCLVARS="FSNOL=${SNOW_NUDGE_COEFF},${CYCLVARS}"
 fi
 
 # determine where the input snow restart files come from
-if [[ ${DO_JEDISNOWDA:-"NO"} = "YES" ]]; then
-    src_dir="${COM_SNOW_ANALYSIS}"
+if [[ "${DO_JEDISNOWDA:-}" == "YES" ]]; then
+    COMIN="${COMIN_SNOW_ANALYSIS}"
 else
-    src_dir="${COM_ATMOS_RESTART_PREV}"
+    COMIN="${COMIN_ATMOS_RESTART_PREV}"
 fi
 
-if [[ ${DOIAU} = "YES" ]]; then
-    # update surface restarts at the beginning of the window, if IAU
-    # For now assume/hold dtfanl.nc valid at beginning of window
-    for n in $(seq 1 ${ntiles}); do
-        ${NCP} "${src_dir}/${bPDY}.${bcyc}0000.sfc_data.tile${n}.nc" \
-               "${COM_ATMOS_RESTART}/${bPDY}.${bcyc}0000.sfcanl_data.tile${n}.nc"
-        ${NLN} "${src_dir}/${bPDY}.${bcyc}0000.sfc_data.tile${n}.nc" "${DATA}/fnbgsi.00${n}"
-        ${NLN} "${COM_ATMOS_RESTART}/${bPDY}.${bcyc}0000.sfcanl_data.tile${n}.nc"   "${DATA}/fnbgso.00${n}"
-        ${NLN} "${FIXgfs}/orog/${CASE}/${CASE}_grid.tile${n}.nc"                         "${DATA}/fngrid.00${n}"
-        ${NLN} "${FIXgfs}/orog/${CASE}/${CASE}.mx${OCNRES}_oro_data.tile${n}.nc"                     "${DATA}/fnorog.00${n}"
-    done
-
-    export APRUNCY=${APRUN_CYCLE}
-    export OMP_NUM_THREADS_CY=${NTHREADS_CYCLE}
-    export MAX_TASKS_CY=${ntiles}
-
-    CDATE="${PDY}${cyc}" ${CYCLESH}
-    export err=$?; err_chk
-fi
-
-# Update surface restarts at middle of window
-for n in $(seq 1 ${ntiles}); do
-    ${NCP} "${src_dir}/${PDY}.${cyc}0000.sfc_data.tile${n}.nc" \
-           "${COM_ATMOS_RESTART}/${PDY}.${cyc}0000.sfcanl_data.tile${n}.nc"
-    ${NLN} "${src_dir}/${PDY}.${cyc}0000.sfc_data.tile${n}.nc" "${DATA}/fnbgsi.00${n}"
-    ${NLN} "${COM_ATMOS_RESTART}/${PDY}.${cyc}0000.sfcanl_data.tile${n}.nc"   "${DATA}/fnbgso.00${n}"
-    ${NLN} "${FIXgfs}/orog/${CASE}/${CASE}_grid.tile${n}.nc"                       "${DATA}/fngrid.00${n}"
-    ${NLN} "${FIXgfs}/orog/${CASE}/${CASE}.mx${OCNRES}_oro_data.tile${n}.nc"                   "${DATA}/fnorog.00${n}"
-done
-
+# global_cycle executable specific variables
 export APRUNCY=${APRUN_CYCLE}
 export OMP_NUM_THREADS_CY=${NTHREADS_CYCLE}
 export MAX_TASKS_CY=${ntiles}
 
-CDATE="${PDY}${cyc}" ${CYCLESH}
-export err=$?; err_chk
+# Copy fix files required by global_cycle to DATA just once
+for (( nn=1; nn <= ntiles; nn++ )); do
+  ${NCP} "${FIXgfs}/orog/${CASE}/${CASE}_grid.tile${nn}.nc"                 "${DATA}/fngrid.00${nn}"
+  ${NCP} "${FIXgfs}/orog/${CASE}/${CASE}.mx${OCNRES}_oro_data.tile${nn}.nc" "${DATA}/fnorog.00${nn}"
+done
+
+# Copy the NSST analysis file for global_cycle
+# There is only a single NSST analysis at the middle of the window
+# For now use/assume it is the same at the beginning of the window if doing IAU
+if [[ "${DONST}" == "YES" ]]; then
+  ${NCP} "${COMIN_ATMOS_ANALYSIS}/${APREFIX}dtfanl.nc" "${DATA}/dtfanl"
+  export NST_FILE="dtfanl"
+else
+  export NST_FILE="NULL"
+fi
+
+# Collect the dates in the window to update surface restarts
+gcycle_dates=("${PDY}${cyc}")  # Always update surface restarts at middle of window
+if [[ "${DOIAU:-}" == "YES" ]]; then  # Update surface restarts at beginning of window
+  half_window=$(( assim_freq / 2 ))
+  BDATE=$(date --utc -d "${PDY} ${cyc} - ${half_window} hours" +%Y%m%d%H)
+  gcycle_dates+=("${BDATE}")
+fi
+
+# Loop over the dates in the window to update the surface restarts
+for gcycle_date in "${gcycle_dates[@]}"; do
+
+  echo "Updating surface restarts for ${gcycle_date} ..."
+
+  datestr="${gcycle_date:0:8}.${gcycle_date:8:2}0000"
+
+  # Copy inputs from COMIN to DATA
+  for (( nn=1; nn <= ntiles; nn++ )); do
+    ${NCP} "${COMIN}/${datestr}.sfc_data.tile${nn}.nc" "${DATA}/fnbgsi.00${nn}"
+    ${NCP} "${COMIN}/${datestr}.sfc_data.tile${nn}.nc" "${DATA}/fnbgso.00${nn}"
+  done
+
+  CDATE="${gcyle_date}" ${CYCLESH}
+  export err=$?; err_chk
+
+  # Copy outputs from DATA to COMOUT
+  for (( nn=1; nn <= ntiles; nn++ )); do
+    ${NCP} "${DATA}/fnbgso.00${nn}" "${COMOUT_ATMOS_RESTART}/${datestr}.sfcanl_data.tile${nn}.nc"
+  done
+
+done
 
 
 ################################################################################
-# Postprocessing
-cd ${pwd}
-[[ ${mkdata} = "YES" ]] && rm -rf ${DATA}
 
-
-################################################################################
-
-exit ${err}
+exit "${err}"
 
 ################################################################################


### PR DESCRIPTION
This patch:
- just cleans up the exglobal_atmos_sfcanl.sh to remove a lot of unused stuff
- updates j-job (and exscript) to identify COMIN and COMOUT more clearly (required by NCO)
- replaces link w/ cp (also required by NCO).  Does the copying a little bit better to save copying same info multiple times