### PR TITLE
Add VarBC for aerosol DA

### DIFF
--- a/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+++ b/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
@@ -25,7 +25,8 @@ YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
 
 RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL \
-    COMIN_CHEM_BMAT_PREV:COM_CHEM_BMAT_TMPL
+    COMIN_CHEM_BMAT_PREV:COM_CHEM_BMAT_TMPL \
+    COMIN_CHEM_ANALYSIS_PREV:COM_CHEM_ANALYSIS_TMPL
 
 ###############################################################
 # Run relevant script

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -11,7 +11,7 @@ from wxflow import (AttrDict,
                     FileHandler,
                     add_to_datetime, to_fv3time, to_timedelta,
                     chdir,
-                    to_fv3time,to_YMDH,
+                    to_fv3time, to_YMDH,
                     YAMLFile, parse_j2yaml, save_as_yaml,
                     logit,
                     Executable,
@@ -155,7 +155,7 @@ class AerosolAnalysis(Analysis):
         biasfiles = glob.glob(os.path.join(self.task_config['DATA'], 'bc', '*bias*.nc4'))
         copylist = []
         for biasfile in biasfiles:
-            if  biasfile.endswith(f'{to_YMDH(self.task_config.current_cycle)}.nc4'):
+            if biasfile.endswith(f'{to_YMDH(self.task_config.current_cycle)}.nc4'):
                 basename = os.path.basename(biasfile)
                 copylist.append([biasfile, os.path.join(self.task_config.COMOUT_CHEM_ANALYSIS, basename)])
         FileHandler({'copy': copylist}).sync()

--- a/ush/python/pygfs/task/aero_analysis.py
+++ b/ush/python/pygfs/task/aero_analysis.py
@@ -11,7 +11,7 @@ from wxflow import (AttrDict,
                     FileHandler,
                     add_to_datetime, to_fv3time, to_timedelta,
                     chdir,
-                    to_fv3time,
+                    to_fv3time,to_YMDH,
                     YAMLFile, parse_j2yaml, save_as_yaml,
                     logit,
                     Executable,
@@ -149,6 +149,16 @@ class AerosolAnalysis(Analysis):
         logger.info(f"Copying files to COM based on {self.task_config.AERO_FINALIZE_VARIATIONAL_TMPL}")
         aero_var_final_list = parse_j2yaml(self.task_config.AERO_FINALIZE_VARIATIONAL_TMPL, self.task_config)
         FileHandler(aero_var_final_list).sync()
+
+        # ---- cooy bias files to COM
+        logger.info('Preparing bias files')
+        biasfiles = glob.glob(os.path.join(self.task_config['DATA'], 'bc', '*bias*.nc4'))
+        copylist = []
+        for biasfile in biasfiles:
+            if  biasfile.endswith(f'{to_YMDH(self.task_config.current_cycle)}.nc4'):
+                basename = os.path.basename(biasfile)
+                copylist.append([biasfile, os.path.join(self.task_config.COMOUT_CHEM_ANALYSIS, basename)])
+        FileHandler({'copy': copylist}).sync()
 
         # open tar file for writing
         with tarfile.open(aerostat, "w") as archive:

--- a/ush/python/pygfs/task/analysis.py
+++ b/ush/python/pygfs/task/analysis.py
@@ -156,9 +156,9 @@ class Analysis(Task):
                 # basename = os.path.basename(obfile)
                 # prefix = '.'.join(basename.split('.')[:-2])
                 # for file in ['satbias.nc', 'satbias_cov.nc', 'tlapse.txt']:
-                    # bfile = f"{prefix}.{file}"
-                    # copylist.append([os.path.join(self.task_config.COMIN_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
-                    # TODO: Why is this specific to ATMOS?
+                #     bfile = f"{prefix}.{file}"
+                #     copylist.append([os.path.join(self.task_config.COMIN_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
+                # TODO: Why is this specific to ATMOS?
 
                 coeffile = ob['obs bias']['input file']
                 basename = os.path.basename(coeffile)

--- a/ush/python/pygfs/task/analysis.py
+++ b/ush/python/pygfs/task/analysis.py
@@ -151,14 +151,22 @@ class Analysis(Task):
         copylist = []
         for ob in observations['observers']:
             if 'obs bias' in ob.keys():
-                obfile = ob['obs bias']['input file']
-                obdir = os.path.dirname(obfile)
-                basename = os.path.basename(obfile)
-                prefix = '.'.join(basename.split('.')[:-2])
-                for file in ['satbias.nc', 'satbias_cov.nc', 'tlapse.txt']:
-                    bfile = f"{prefix}.{file}"
-                    copylist.append([os.path.join(self.task_config.COM_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
+               # obfile = ob['obs bias']['input file']
+               # obdir = os.path.dirname(obfile)
+               # basename = os.path.basename(obfile)
+               # prefix = '.'.join(basename.split('.')[:-2])
+               # for file in ['satbias.nc', 'satbias_cov.nc', 'tlapse.txt']:
+               #     bfile = f"{prefix}.{file}"
+               #     copylist.append([os.path.join(self.task_config.COMIN_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
                     # TODO: Why is this specific to ATMOS?
+
+
+                coeffile = ob['obs bias']['input file']
+                basename = os.path.basename(coeffile)
+                copylist.append([os.path.join(self.task_config.COMIN_CHEM_ANALYSIS_PREV, basename), coeffile])
+                errfile = ob['obs bias']['covariance']['prior']['input file']
+                basename = os.path.basename(errfile)
+                copylist.append([os.path.join(self.task_config.COMIN_CHEM_ANALYSIS_PREV, basename), errfile])
 
         bias_dict = {
             'mkdir': [os.path.join(self.task_config.DATA, 'bc')],

--- a/ush/python/pygfs/task/analysis.py
+++ b/ush/python/pygfs/task/analysis.py
@@ -151,15 +151,14 @@ class Analysis(Task):
         copylist = []
         for ob in observations['observers']:
             if 'obs bias' in ob.keys():
-               # obfile = ob['obs bias']['input file']
-               # obdir = os.path.dirname(obfile)
-               # basename = os.path.basename(obfile)
-               # prefix = '.'.join(basename.split('.')[:-2])
-               # for file in ['satbias.nc', 'satbias_cov.nc', 'tlapse.txt']:
-               #     bfile = f"{prefix}.{file}"
-               #     copylist.append([os.path.join(self.task_config.COMIN_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
+                # obfile = ob['obs bias']['input file']
+                # obdir = os.path.dirname(obfile)
+                # basename = os.path.basename(obfile)
+                # prefix = '.'.join(basename.split('.')[:-2])
+                # for file in ['satbias.nc', 'satbias_cov.nc', 'tlapse.txt']:
+                    # bfile = f"{prefix}.{file}"
+                    # copylist.append([os.path.join(self.task_config.COMIN_ATMOS_ANALYSIS_PREV, bfile), os.path.join(obdir, bfile)])
                     # TODO: Why is this specific to ATMOS?
-
 
                 coeffile = ob['obs bias']['input file']
                 basename = os.path.basename(coeffile)


### PR DESCRIPTION
# Description
This PR adds in VarBC configuration for aerosol DA. This PR copy the input bias files to {DATA}/bc and copy back the output bias files to analysis/chem. 

# Type of change
<!-- Delete all except one -->
- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO
- Does this change require an update to any of the following submodules? NO

# How has this been tested?
- Cycled test on Hera

# Checklist
- [ ] Any dependent changes have been merged and published
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
