### PR TITLE
fixes for prep_emissions NRT

### DIFF
--- a/parm/config/gcafs/config.aero
+++ b/parm/config/gcafs/config.aero
@@ -77,10 +77,10 @@ export AERO_EMIS_FIRE_VERSION="004"
 # On WCOSS2, points to DCOM (Data Communication) root for operational runs; empty for testing.
 # Processed by scripts like exglobal_prep_emissions.py to generate input files for GOCART.
 #---------------------------------------------------------------------------------------------------
-export AERO_EMIS_FIRE_HIST=1 # Use historical fire emissions | 1 = true 0 = false
+export AERO_EMIS_FIRE_HIST=0 # Use historical fire emissions | 1 = true 0 = false
 
 #---------------------------------------------------------------------------------------------------
-export FIRE_EMIS_NRT_DIR="" #TODO: set to DCOM for WCOSS2 "${DCOMROOT}/YYYYMMDD/firewx" # Directory containing NRT fire emissions
+export FIRE_EMIS_NRT_DIR="${DCOMROOT}" #TODO: set to DCOM for WCOSS2 "${DCOMROOT}/YYYYMMDD/firewx" # Directory containing NRT fire emissions
 export FIRE_EMIS_DIR="${HOMEgcafs}/fix/chem/Emission_data/fires_data/GBBEPx/v4" # Directory containing historical fire emissions
 
 

--- a/ush/python/pygfs/task/chem_fire_emission.py
+++ b/ush/python/pygfs/task/chem_fire_emission.py
@@ -94,7 +94,7 @@ class ChemFireEmissions(Task):
         Notes
         -----
         The method expects the following configuration to be available:
-        - HOMEgfs : str
+        - HOMEgcafs : str
             Base directory containing workflow configuration
         - DATA : str
             Working directory path
@@ -121,7 +121,7 @@ class ChemFireEmissions(Task):
             logger.info(f'Using AERO_EMIS_FIRE: {aero_emis_fire}')
             logger.info(f'Using AERO_EMIS_FIRE_VERSION: {aero_emis_fire_version}')
 
-            fire_emission_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
+            fire_emission_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
             if not os.path.exists(fire_emission_template):
                 raise WorkflowException(f"Fire emission template file not found: {fire_emission_template}")
 
@@ -162,7 +162,8 @@ class ChemFireEmissions(Task):
             # GBBEPx NRT files are in a different directory structure
             # Render the template with the current cycle to get the correct path
             tmp_dict = {'sdate': self.start_date,
-                        'FIRE_EMIS_NRT_DIR': self.task_config.FIRE_EMIS_NRT_DIR}
+                        'FIRE_EMIS_NRT_DIR': self.task_config.FIRE_EMIS_NRT_DIR,
+                        'nmem_ens': self.task_config.NMEM_ENS}
             yaml_config = self.render_template(tmp_dict)
             if self.task_config.AERO_EMIS_FIRE.lower() == 'gbbepx':
                 self.task_config['AERO_EMIS_FIRE_DIR'] = yaml_config.fire_emission.config.NRT_DIRECTORY
@@ -214,7 +215,7 @@ class ChemFireEmissions(Task):
         }
 
         # Parse template and update task configuration
-        yaml_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
+        yaml_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
         if not os.path.exists(yaml_template):
             logger.warning(f"Template file not found: {yaml_template}, using default configuration")
             yaml_config = {'fire_emission': {}}
@@ -936,7 +937,7 @@ class ChemFireEmissions(Task):
         """
         logger.info("Rendering YAML template")
         # Parse template and update task configuration
-        yaml_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
+        yaml_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
         if not os.path.exists(yaml_template):
             logger.warning(f"Template file not found: {yaml_template}, using default configuration")
             yaml_config = {'fire_emission': {}}

--- a/ush/python/pygfs/task/chem_fire_emission.py
+++ b/ush/python/pygfs/task/chem_fire_emission.py
@@ -94,7 +94,7 @@ class ChemFireEmissions(Task):
         Notes
         -----
         The method expects the following configuration to be available:
-        - HOMEgcafs : str
+        - HOMEgfs : str
             Base directory containing workflow configuration
         - DATA : str
             Working directory path
@@ -121,7 +121,7 @@ class ChemFireEmissions(Task):
             logger.info(f'Using AERO_EMIS_FIRE: {aero_emis_fire}')
             logger.info(f'Using AERO_EMIS_FIRE_VERSION: {aero_emis_fire_version}')
 
-            fire_emission_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
+            fire_emission_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
             if not os.path.exists(fire_emission_template):
                 raise WorkflowException(f"Fire emission template file not found: {fire_emission_template}")
 
@@ -215,7 +215,7 @@ class ChemFireEmissions(Task):
         }
 
         # Parse template and update task configuration
-        yaml_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
+        yaml_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
         if not os.path.exists(yaml_template):
             logger.warning(f"Template file not found: {yaml_template}, using default configuration")
             yaml_config = {'fire_emission': {}}
@@ -937,7 +937,7 @@ class ChemFireEmissions(Task):
         """
         logger.info("Rendering YAML template")
         # Parse template and update task configuration
-        yaml_template = os.path.join(self.task_config.HOMEgcafs, 'parm', 'chem', 'fire_emission.yaml.j2')
+        yaml_template = os.path.join(self.task_config.HOMEgfs, 'parm', 'chem', 'fire_emission.yaml.j2')
         if not os.path.exists(yaml_template):
             logger.warning(f"Template file not found: {yaml_template}, using default configuration")
             yaml_config = {'fire_emission': {}}


### PR DESCRIPTION
This pull request updates the configuration and Python workflow for handling fire emissions in the GCAFS system. The main changes focus on aligning directory references to use `HOMEgcafs` instead of `HOMEgfs`, updating the use of historical fire emissions, and ensuring the correct directories and parameters are passed for near-real-time (NRT) fire emissions.

**Configuration updates:**

* Changed `AERO_EMIS_FIRE_HIST` to `0` in `config.aero`, disabling the use of historical fire emissions by default.
* Set `FIRE_EMIS_NRT_DIR` to use `${DCOMROOT}` for NRT fire emissions, ensuring the correct directory is referenced.

**Python workflow and path corrections:**

* Updated all references from `HOMEgfs` to `HOMEgcafs` in `chem_fire_emission.py` to ensure the workflow uses the correct base directory for GCAFS configuration and template files. [[1]](diffhunk://#diff-63104b677959eb4df4b78727714d28cef64b17f6c8d5d145eff5ea4193317f44L97-R97) [[2]](diffhunk://#diff-63104b677959eb4df4b78727714d28cef64b17f6c8d5d145eff5ea4193317f44L124-R124) [[3]](diffhunk://#diff-63104b677959eb4df4b78727714d28cef64b17f6c8d5d145eff5ea4193317f44L217-R218) [[4]](diffhunk://#diff-63104b677959eb4df4b78727714d28cef64b17f6c8d5d145eff5ea4193317f44L939-R940)
* Added `nmem_ens` (ensemble member count) to the template rendering dictionary in the fire emission task, allowing the template to access this parameter if needed.